### PR TITLE
Recognize quoted strings when parsing operands

### DIFF
--- a/server/src/parse.ts
+++ b/server/src/parse.ts
@@ -48,11 +48,11 @@ export interface ComponentInfo {
 //     )
 //     |
 //     (                                 Any other mnemonic:
-//       (?<mnemonic>\.?([a-z0-9_]+|=))   - Mnemonic
-//       (?<size>\.[a-z0-9_.]*)?          - Size qualifier
-//       (\s*(?<operands>                 - Operand list:
-//         [^\s;,]+                         - first operand
-//         (,\s*[^\s;,]*)*                  - additional comma separated operands
+//       (?<mnemonic>\.?([a-z0-9_]+|=))             - Mnemonic
+//       (?<size>\.[a-z0-9_.]*)?                    - Size qualifier
+//       (\s*(?<operands>                           - Operand list:
+//         ([^\s;"',]+|"([^"]*)"|'([^']*)')         - first operand
+//         (,\s*[^\s;"',]*|"([^"]*)"|'([^']*)')*    - additional comma separated operands
 //       ))?
 //     )
 //   )
@@ -60,8 +60,7 @@ export interface ComponentInfo {
 // (\s*(?<comment>.+))?                Comment (any trailing text)
 // $
 const pattern =
-  /^(?<label>([a-z0-9_.$\\]+:?)|(\s*[a-z0-9_.$\\]+:))?(\s*(((?<mnemonic1>\.?(nop|reset|rte|rtr|rts|trapv|illegal|clrfo|clrso|comment|einline|even|inline|list|mexit|nolist|nopage|odd|page|popsection|pushsection|rsreset|endif|endc|else|elseif|endm|endr|erem))(?<size1>\.[a-z0-9_.]*)?)|((?<mnemonic>\.?([a-z0-9_]+|=))(?<size>\.[a-z0-9_.]*)?(\s*(?<operands>[^\s;,]+(,\s*[^\s;,]*)*))?)))?(\s*(?<comment>.+))?$/i;
-
+  /^(?<label>([a-z0-9_.$\\]+:?)|(\s*[a-z0-9_.$\\]+:))?(\s*(((?<mnemonic1>\.?(nop|reset|rte|rtr|rts|trapv|illegal|clrfo|clrso|comment|einline|even|inline|list|mexit|nolist|nopage|odd|page|popsection|pushsection|rsreset|endif|endc|else|elseif|endm|endr|erem))(?<size1>\.[a-z0-9_.]*)?)|((?<mnemonic>\.?([a-z0-9_]+|=))(?<size>\.[a-z0-9_.]*)?(\s*(?<operands>([^\s;"',]+|"([^"]*)"|'([^']*)')(,\s*[^\s;"',]*|"([^"]*)"|'([^']*)')*))?)))?(\s*(?<comment>.+))?$/i;
 /**
  * Parse a single line of source code into positional components
  *


### PR DESCRIPTION
I was experimenting with using this LSP in Neovim and noticed that the formatter would not take quoted strings into consideration, eg.:
```
test_string:
    dc.b    "test string"    ;comment
```
It would assume a space after an operand always meant the end of the match, so it inserted extra spaces into the string:
```
test_string:
    dc.b    "test            string"    ;comment
```

This is a small adjustment to the parser regex so that an operand match is either the previous logic (a string ended by `\s` or `;`) OR a string enclosed in quotes, which may contain any characters.

I apologize in advance if contributions aren't welcome, but I saw this simple fix and thought it would be preferable over opening an issue.