### PR TITLE
Fix startup issues (in Emacs and possibly other lsp-clients)

### DIFF
--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -47,15 +47,15 @@ export function mergeDefaults(config: Partial<Config>): Config {
     ...config,
     format: {
       ...defaultConfig.format,
-      ...config.format,
+      ...config?.format,
       align: {
         ...defaultConfig.format.align,
-        ...config.format?.align,
+        ...config?.format?.align,
       },
     },
     vasm: {
       ...defaultConfig.vasm,
-      ...config.vasm,
+      ...config?.vasm,
     },
   };
 }

--- a/server/src/diagnostics.ts
+++ b/server/src/diagnostics.ts
@@ -46,9 +46,9 @@ export default class DiagnosticProcessor {
 
     // Get path of file relative to workspace
     const workspace =
-      this.ctx.workspaceFolders.find((ws) => uri.startsWith(ws.uri)) ??
+      this.ctx.workspaceFolders.find((ws) => uri.startsWith(ws?.uri)) ??
       this.ctx.workspaceFolders[0];
-    const wsPath = URI.parse(workspace.uri).fsPath;
+    const wsPath = URI.parse(workspace?.uri)?.fsPath;
     const wsRelative = relative(wsPath, srcPath);
 
     // Does path match any exclude patterns?


### PR DESCRIPTION
I'm currently experimenting with creating an Emacs extension that uses m68k-lsp, as well as your uae-dap package for debugging. Both packages are awesome btw! ❤️  Now back to the point....

When I first tried to make some lsp-mode config for Emacs, I saw that the server crashed during startup. It seemed to expect that the m68k-config parameters  were part of the init-call, and many LSP-clients, including Emacs lsp-mode, sends them later. This caused some null/undefined issues during startup. This PR simply adds some extra null checks, so that the lsp server starts without issues for Emacs as well (and maybe other LSP clients) 😄 